### PR TITLE
Replace autohelm with reckoner.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Tools, Extras
 Helm-related tools
 * [Keel.sh](https://keel.sh) - Continuous delivery for Kubernetes - enhances Helm with auto upgrades and other cool features
 * [Helmfile](https://github.com/roboll/helmfile) - Helmfile is a declarative spec for deploying helm charts
-* [Autohelm](https://github.com/reactiveops/autohelm) - autohelm is a tool to simplify management and installation of multiple releases
+* [Reckoner](https://github.com/reactiveops/reckoner) - Reckoner is a tool to simplify management and installation of multiple Helm chart releases
 * [Monocular](https://github.com/helm/monocular) - A web-based application that enables the search and discovery of charts from multiple Helm Chart repositories
 * [Ship](https://github.com/replicatedhq/ship) - A tool that makes it easy to watch and apply updates to Helm charts and integrates [Kustomize](https://kustomize.io) patches and overlays
 


### PR DESCRIPTION
Autohelm was recently deprecated and development continued in the new Reckoner package.  I replaced the autohelm entry with Reckoner.