### PR TITLE
Added Cloudsmith (Kubernetes Registry / Docker + Helm)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Official Kubernetes Helm repositories
 
 3rd party repositories / hubs
 
+* [Cloudsmith](https://cloudsmith.io/l/helm-repository/) - A fully managed package management SaaS, with first-class support for public and private Kubernetes registries (Docker + Helm Charts, plus many others). Has a generous free-tier and is also completely free for open-source.
 * [Fabric8](https://fabric8.io/helm/) - chart repository by Fabric8
 * [Kubeapps](https://hub.kubeapps.com/) - Kubeapps helm chart hub by Bitnami
 


### PR DESCRIPTION
Hi! This PR adds a link to [Cloudsmith](https://cloudsmith.io), which is a package management service SaaS. It's commercial, but it is completely free for open-source and it has generous free tiers otherwise. It has first-class support for Kubernetes / Docker + Helm (and many other package formats, such as Npm), plus org/teams management, granular access controls, private repositories, repository-specific entitlements, a worldwide content distribution network, webhooks, access logs, etc. Thank you. :-)

Full disclosure: I work at Cloudsmith. \o/