### PR TITLE
Add chart-viewer to tools list

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Helm-related tools
 * [Helm-Starter-Istio](https://github.com/salesforce/helm-starter-istio) - A helm starer for creating [Istio](https://istio.io/) managed services
 * [Helm Broker](https://github.com/kyma-project/helm-broker) - A Service Broker which exposes Helm charts as Service Classes in the [Service Catalog](https://svc-cat.io/)
 * [Chart Releaser](https://github.com/helm/chart-releaser) - Helps Turn GitHub Repositories into Helm Chart Repositories
+* [Chart Viewer](https://github.com/ecojuntak/chart-viewer) - Helps you inspect and compare chart template and also rendered manifest
 
 
 Community


### PR DESCRIPTION
Hi folks, here I want to add my personal project, I named Chart Viewer

So chart-viewer is a tool that helps you to
- Inspect helm chart; as simple as showing all the chart templates
- Compare template between two versions; showing changes in git-like view.
- Compare rendered manifest between two versions; showing changes in git-like view.
- Render Kubernetes manifest; modify the values.yaml and render the manifest. You will get a link that you can use to directly create the Kubernetes resources on your cluster, as simple as kubectl apply -f http://the.given.link

The problem that this tool helps to solve is:
- Understand the changes between two chart templates
- Understand the changes between two rendered manifests

For example, currently, I used nginx chart v6.0.5. Then nginx release a new feature, so I need to upgrade your nginx by upgrading the chart version to v6.2.6. But I don't really know the changes between v6.0.5 and v6.2.6. There are two ways that I can do to know the changes. First, look at the commits on the repo. The second is pulling the chart to my local machine then run the helm cli command to show the manifest. Since those ways quite tedious, at least for me, so I build chart viewer to help me.

Chart viewer is safe used for production.