### PR TITLE
Add helm blob plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ These usually hold a single chart or a group of connected charts. Can be more up
 Plugins
 -------
 
+* [Helm Blob](https://github.com/C123R/helm-blob) - Plugin that allows you to manage helm repositories on the blob storage like Azure Blob, GCS, S3, etc.
 * [Helm Diff](https://github.com/databus23/helm-diff) - Plugin that shows a diff explaing what a `helm upgrade` and `helm rollback` would change. It can also compare two separate revisions of the release.
 * [Helm Env](https://github.com/adamreese/helm-env) - Plugin to show the environment variables available to a helm plugin.
 * [Helm Last](https://github.com/adamreese/helm-last) - Plugin that shows the latest release interacted with. This is useful for chaining commands together like `helm status $(helm last)`.


### PR DESCRIPTION
[helm-blob ](https://github.com/C123R/helm-blob) plugin allows you to manage helm repositories on the blob storage like Azure Blob, GCS, S3, etc. This plugin supports operations like uploading or deletion of charts from remote Helm Repository hosted on Blob Storage.

Technically it could support any blob storage supported by [GoCDK](https://gocloud.dev/howto/blob/)