### PR TITLE
Adds helm-dt plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Plugins
 
 * [Helm Blob](https://github.com/C123R/helm-blob) - Plugin that allows you to manage helm repositories on the blob storage like Azure Blob, GCS, S3, etc.
 * [Helm Diff](https://github.com/databus23/helm-diff) - Plugin that shows a diff explaing what a `helm upgrade` and `helm rollback` would change. It can also compare two separate revisions of the release.
+* [Helm Dt](https://github.com/vmware-labs/distribution-tooling-for-helm) - Plugin that helps moving Helm charts across OCI registries.
 * [Helm Env](https://github.com/adamreese/helm-env) - Plugin to show the environment variables available to a helm plugin.
 * [Helm Last](https://github.com/adamreese/helm-last) - Plugin that shows the latest release interacted with. This is useful for chaining commands together like `helm status $(helm last)`.
 * [Helm Local](https://github.com/adamreese/helm-local) - Plugin to run Tiller (helm 2's server-side component) as a local daemon.


### PR DESCRIPTION
Adding this plugin that we recently created for moving Helm charts with dependencies cross OCI registries.