### PR TITLE
Add Readme Generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Helm-related tools
 * [ChartMuseum](https://chartmuseum.com/) - ChartMuseum is an open-source, easy to deploy, Helm Chart Repository server.
 * [Helmify](https://github.com/arttor/helmify) - Generates a Helm chart from Kubernetes yamls
 * [Helm Docs](https://github.com/norwoodj/helm-docs) - Auto-generates documentation from helm charts into markdown files
+* [Readme Generator](https://github.com/bitnami-labs/readme-generator-for-helm) - Autogenerate Helm Charts READMEs' tables based on values YAML file metadata.
 * [Chart Viewer](https://github.com/ecojuntak/chart-viewer) - Helps you inspect and compare chart template and also rendered manifest
 * [werf](https://werf.io/) - A CLI tool for implementing CI/CD best practices using an extended version of Helm under the hood for deployment
 


### PR DESCRIPTION
Adding Readme Generator to the plugins list.

Plugin allows to: 
* Autogenerate Helm Charts READMEs' tables based on values YAML file metadata.
* Autogenerate an OpenAPI compliant JSON schema defining the values.yaml structure of the Helm Chart. The file generated will be a JSON file formatted according to the [OpenAPIv3 SchemaObject](https://spec.openapis.org/oas/v3.1.0#schema-object) definition.