### PR TITLE
Add Helm Kanvas Snapshot Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Plugins
 * [Helm Release](https://github.com/JovianX/helm-release-plugin) - Plugin that pulls(re-creates) Helm charts from deployed releases, also allows update values of deployed releases without supplying the chart(for modified or custom charts, or when there's no access to the chart)
 * [Helm Compose](https://github.com/seacrew/helm-compose) - Plugin that allows coupled multi release handling of one or many charts. With full configuration-as-code capabilities in a single yaml file similar to docker-compose.
 * [Helm Unittest](https://github.com/helm-unittest/helm-unittest) - Plugin that enables you to run BDD style unit tests against rendered Helm charts. Adds the `helm unittest` command to execute tests.
+* [Helm Kanvas Snapshot](https://github.com/meshery/helm-kanvas-snapshot) - Plugin that generates a visual snapshot of Helm charts.
 
 
 Tools, Extras


### PR DESCRIPTION
This PR lists [Helm Kanvas Snapshot](https://github.com/meshery/helm-kanvas-snapshot) plugin that enables Helm users to generate visual snapshot of their helm charts.