### PR TITLE
add helm-tree plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Plugins
 * [Helm Schema Gen](https://github.com/karuppiah7890/helm-schema-gen) - So that you don't have to write `values.schema.json` by hand from scratch for your Helm 3 charts
 * [Helm Datree](https://github.com/datreeio/helm-datree) - Plugin to prevent Kubernetes misconfigurations by ensuring that Helm charts follow best practices as well as your organization’s policies
 * [Helm Teller](https://github.com/SpectralOps/helm-teller) - Plugin that allows you to manage deployment configuration and secrets from multiple providers securely with [Teller](https://github.com/SpectralOps/teller)
+* [Helm Tree](https://github.com/major1201/helm-tree) - Plugin that shows the manifests resources tree of a release.
 * [Helm Release](https://github.com/JovianX/helm-release-plugin) - Plugin that pulls(re-creates) Helm charts from deployed releases, also allows update values of deployed releases without supplying the chart(for modified or custom charts, or when there's no access to the chart)
 * [Helm Compose](https://github.com/seacrew/helm-compose) - Plugin that allows coupled multi release handling of one or many charts. With full configuration-as-code capabilities in a single yaml file similar to docker-compose.
 * [Helm Unittest](https://github.com/helm-unittest/helm-unittest) - Plugin that enables you to run BDD style unit tests against rendered Helm charts. Adds the `helm unittest` command to execute tests.


### PR DESCRIPTION
This PR adds [Helm Tree](https://github.com/major1201/helm-tree) plugin that shows the manifests resources tree of a release.