### PR TITLE
tools: add kubesafe

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Tools, Extras
 -------------
 Helm-related tools
 * [Keel.sh](https://keel.sh) - Continuous delivery for Kubernetes - enhances Helm with auto upgrades and other cool features
+* [Kubesafe](https://github.com/Telemaco019/kubesafe) - Safely manage multiple Kubernetes clusters by defining safe contexts and protected commands.
 * [Helmfile](https://github.com/roboll/helmfile) - Helmfile is a declarative spec for deploying helm charts, supports flexible templating scenarios
 * [Helmsman](https://github.com/Praqma/helmsman) - Helmsman provides a declarative way of installing charts, features terraform-like desired state file approach and security enhancements
 * [Reckoner](https://github.com/FairwindsOps/reckoner) - Reckoner is a tool to simplify management and installation of multiple Helm chart releases


### PR DESCRIPTION
The PR adds [kubesafe](https://github.com/Telemaco019/kubesafe) to the tools section.