### PR TITLE
Add segspec

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Helm-related tools
 * [Helm Docs](https://github.com/norwoodj/helm-docs) - Auto-generates documentation from helm charts into markdown files
 * [Readme Generator](https://github.com/bitnami-labs/readme-generator-for-helm) - Autogenerate Helm Charts READMEs' tables based on values YAML file metadata.
 * [Chart Viewer](https://github.com/ecojuntak/chart-viewer) - Helps you inspect and compare chart template and also rendered manifest
+* [segspec](https://github.com/dormstern/segspec) - Extracts network dependencies from Helm charts and other config files, generates Kubernetes NetworkPolicies with evidence tracing
 * [werf](https://werf.io/) - A CLI tool for implementing CI/CD best practices using an extended version of Helm under the hood for deployment
 
 


### PR DESCRIPTION
Add [segspec](https://github.com/dormstern/segspec) to the Tools, Extras section.

segspec is an open-source CLI that extracts network dependencies from Helm charts and other config files, then generates Kubernetes NetworkPolicies with evidence tracing. Single Go binary, MIT license.