### PR TITLE
Add Ingero - eBPF-based GPU observability Helm chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ These usually hold a single chart or a group of connected charts. Can be more up
 * [Gitlab Omnibus](https://charts.gitlab.io) - an All-In-One chart for deploying Gitlab in Kubernetes
 * [Jupyterhub and Binderhub](https://jupyterhub.github.io/helm-chart/) - charts for deploying services to run Jupyter notebooks
 * [Harbor](https://github.com/goharbor/harbor-helm) - Harbor is a container and Helm registry with built-in security
+* [Ingero](https://github.com/ingero-io/ingero) - eBPF-based GPU causal observability agent. Helm chart deploys as DaemonSet with RBAC, traces CUDA APIs and host kernel events to explain GPU latency.
 * [OpenStack](https://github.com/openstack/openstack-helm) - various charts by the OpenStack project
 * [Fn Project](https://github.com/fnproject/fn-helm) - Fn serverless platform charts
 * [Lenses](https://github.com/Landoop/kafka-helm-charts) - charts for Lenses, Apache Kafka, Kafka Connect and other components for data streaming and data integration


### PR DESCRIPTION
## What

Adds [Ingero](https://github.com/ingero-io/ingero) to the Application repositories section.

Ingero is an open-source, eBPF-based GPU causal observability agent. It ships with a Helm chart (`deploy/helm/ingero/`) that deploys as a DaemonSet with full RBAC, tracing CUDA Runtime/Driver APIs and host kernel events (scheduler, memory, I/O) to build causal chains explaining GPU latency in production Kubernetes clusters.

Key features:
- Zero-config, <2% overhead, production-safe
- Kernel uprobes on libcudart.so and libcuda.so (no CUPTI dependency)
- Host kernel tracepoints (sched_switch, block I/O, TCP retransmits, network socket I/O)
- 4-layer causal chain engine with automated root cause analysis
- MCP server for AI-assisted GPU debugging
- Helm chart with DaemonSet, RBAC, and ServiceAccount configuration