### PR TITLE
feat: add Helm Chart Compatibility Checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ Helm-related tools
 * [werf](https://werf.io/) - A CLI tool for implementing CI/CD best practices using an extended version of Helm under the hood for deployment
 
 
+* [Helm Chart Compatibility Checker](https://releaserun.com/tools/helm-checker/) - Free browser-based tool to check Helm chart API version compatibility with your target Kubernetes version. Catches deprecated and removed APIs before deployment.
+
 Community
 ---------
 Forums, discussion groups, SO tags.


### PR DESCRIPTION
## What

Adds **[Helm Chart Compatibility Checker](https://releaserun.com/tools/helm-checker/)** to the Tools section.

## Why

This tool checks Helm chart API version compatibility with a target Kubernetes version. It catches deprecated and removed Kubernetes APIs (like those dropped in K8s 1.25, 1.26, 1.27) before deployment, which is directly relevant to Helm users managing chart upgrades.

Free, browser-based, no signup. Fits naturally alongside Chart Testing and other CI/CD tools in the list.