### PR TITLE
Add Qovery to Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Helm-related tools
 * [Readme Generator](https://github.com/bitnami-labs/readme-generator-for-helm) - Autogenerate Helm Charts READMEs' tables based on values YAML file metadata.
 * [Chart Viewer](https://github.com/ecojuntak/chart-viewer) - Helps you inspect and compare chart template and also rendered manifest
 * [werf](https://werf.io/) - A CLI tool for implementing CI/CD best practices using an extended version of Helm under the hood for deployment
+* [Qovery](https://www.qovery.com/) - Enterprise Kubernetes management platform that natively deploys Helm charts from public/private repositories or Git repos. Includes Terraform provider, CLI, API, and [AI Agent Skill](https://github.com/Qovery/qovery-skills) for AI-assisted deployment.
 
 
 Community


### PR DESCRIPTION
Adds [Qovery](https://www.qovery.com) — an enterprise Kubernetes management platform for deploying applications, databases, Helm charts, and Terraform modules on AWS, GCP, Azure, and Scaleway. Includes a Terraform provider, CLI, REST API, and an [AI Agent Skill](https://github.com/Qovery/qovery-skills) for deploying from Claude Code, Cursor, OpenCode, and 30+ AI coding tools.

Website: https://www.qovery.com
GitHub: https://github.com/Qovery
Documentation: https://www.qovery.com/docs/getting-started/introduction