### PR TITLE
Add YAML Validator to Tools, extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Helm-related tools
 * [Readme Generator](https://github.com/bitnami-labs/readme-generator-for-helm) - Autogenerate Helm Charts READMEs' tables based on values YAML file metadata.
 * [Chart Viewer](https://github.com/ecojuntak/chart-viewer) - Helps you inspect and compare chart template and also rendered manifest
 * [werf](https://werf.io/) - A CLI tool for implementing CI/CD best practices using an extended version of Helm under the hood for deployment
+* [YAML Validator](https://yamlvalidator.dev) - Online YAML validator and [Chrome extension](https://chromewebstore.google.com/detail/yaml-validator/gjgbohnlhijomhfiflapnlnmcpckgigg) with JSON Schema support for Helm Charts, Kubernetes, and other formats, plus YAML code folding on GitHub
 
 
 Community


### PR DESCRIPTION
Adding [YAML Validator](https://yamlvalidator.dev) to the **Tools, extras** section.

**YAML Validator** is an online YAML validator and [Chrome extension](https://chromewebstore.google.com/detail/yaml-validator/gjgbohnlhijomhfiflapnlnmcpckgigg) with JSON Schema support for Helm Charts, Kubernetes, and other formats. It also adds YAML code folding on GitHub.

Thanks for maintaining this awesome list!