### PR TITLE
feat: add KubeStellar Console to Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Helm-related tools
 * [Readme Generator](https://github.com/bitnami-labs/readme-generator-for-helm) - Autogenerate Helm Charts READMEs' tables based on values YAML file metadata.
 * [Chart Viewer](https://github.com/ecojuntak/chart-viewer) - Helps you inspect and compare chart template and also rendered manifest
 * [werf](https://werf.io/) - A CLI tool for implementing CI/CD best practices using an extended version of Helm under the hood for deployment
+* [KubeStellar Console](https://github.com/kubestellar/console) - Multi-cluster Kubernetes dashboard with Helm chart deployment, deployed via its own Helm chart for easy installation
 
 
 Community


### PR DESCRIPTION
Add [KubeStellar Console](https://github.com/kubestellar/console) to the Tools, Extras section.

KubeStellar Console is a multi-cluster Kubernetes dashboard deployed via its own [Helm chart](https://github.com/kubestellar/console/tree/main/deploy/helm). It provides real-time observability and AI-powered operations across edge and cloud clusters.

- **Open source**: [github.com/kubestellar/console](https://github.com/kubestellar/console)
- **CNCF Sandbox project**
- **Helm chart**: [deploy/helm](https://github.com/kubestellar/console/tree/main/deploy/helm)