### PR TITLE
Add AgentTier chart to Application repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ These usually hold a single chart or a group of connected charts. Can be more up
 * [Bitwarden](https://github.com/cdwv/bitwarden-k8s) - Helm chart for deploying bitwarden-rs - unofficial Bitwarden-compatible server
 * [Elastic](https://github.com/elastic/helm-charts/) - Official helm charts for [Elatic.co](https://www.elastic.co/)'s open source products (ElasticSearch, Kibana & filebeat)
 * [Mocktail](https://github.com/Huseyinnurbaki/mocktail) - Helm chart for deploying the free, tiny mock api server Mocktail
+* [AgentTier](https://github.com/agenttier/agenttier) - Helm chart for an open-source Kubernetes-native operator that provisions isolated, persistent sandboxes for human developers and AI agents through a Sandbox CRD. Chart at https://agenttier.github.io/agenttier/charts.
 
 Plugins
 -------


### PR DESCRIPTION
This PR adds [AgentTier](https://github.com/agenttier/agenttier) under `Application repositories`.

AgentTier is an open-source Kubernetes-native operator that provisions isolated, persistent sandboxes for both human developers and AI coding agents through a `Sandbox` CRD (Pod + PVC + default-deny NetworkPolicy, optional gVisor isolation, browser terminal, streaming agent-mode REST API).

The whole platform — controller, router, web UI, CRDs, RBAC, and optional add-ons (gVisor RuntimeClass, ServiceMonitor, PodDisruptionBudget, image pre-pull DaemonSet, OTel Collector, ALB ingress, warm pod pool, governance ConfigMap) — installs from a single Helm chart at https://agenttier.github.io/agenttier/charts:

```
helm repo add agenttier https://agenttier.github.io/agenttier/charts
helm repo update
helm install agenttier agenttier/agenttier --namespace agenttier --create-namespace
```

License: Apache-2.0. Latest chart version: v0.3.0 (2026-05-13).

**Compliance with CONTRIBUTING.md:**

- ✅ One link per item, link is the project repo.
- ✅ Description follows the link on the same line, clear and concise.
- ✅ Single PR, single line addition appended at the end of `Application repositories` (no conflict-prone same-line edits).
- ✅ Quality: actively maintained (last release yesterday), CI green, cosign-signed images, SBOMs attached, public Helm repo via GitHub Pages.
- ✅ Disclosure: I'm a contributor to AgentTier, submitting because the chart fits the section's scope (single project shipping its own Helm chart).
