### PR TITLE
Add AgentTier chart to Application repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ These usually hold a single chart or a group of connected charts. Can be more up
 * [Bitwarden](https://github.com/cdwv/bitwarden-k8s) - Helm chart for deploying bitwarden-rs - unofficial Bitwarden-compatible server
 * [Elastic](https://github.com/elastic/helm-charts/) - Official helm charts for [Elatic.co](https://www.elastic.co/)'s open source products (ElasticSearch, Kibana & filebeat)
 * [Mocktail](https://github.com/Huseyinnurbaki/mocktail) - Helm chart for deploying the free, tiny mock api server Mocktail
+* [AgentTier](https://github.com/agenttier/agenttier) - Helm chart for an open-source Kubernetes-native operator that provisions isolated, persistent sandboxes for human developers and AI agents through a Sandbox CRD.
 * [KubeStellar Console](https://github.com/kubestellar/console) - AI-powered multi-cluster Kubernetes management console with built-in Helm chart for one-command deployment
 
 Plugins


### PR DESCRIPTION
This PR adds [AgentTier](https://github.com/agenttier/agenttier) under `Application repositories`.

AgentTier is an open-source Kubernetes-native operator that provisions isolated, persistent sandboxes for both human developers and AI coding agents through a `Sandbox` CRD (Pod + PVC + default-deny NetworkPolicy, optional gVisor isolation, browser terminal, streaming agent-mode REST API).

The whole platform — controller, router, web UI, CRDs, RBAC, and optional add-ons (gVisor RuntimeClass, ServiceMonitor, PodDisruptionBudget, image pre-pull DaemonSet, OTel Collector, ALB ingress, warm pod pool, governance ConfigMap) — installs from a single Helm chart.

License: Apache-2.0. Latest chart version: v0.3.5.

**Compliance with CONTRIBUTING.md:**

- ✅ One link per item, link is the project repo.
- ✅ Description follows the link on the same line, clear and concise.
- ✅ Single PR, single line addition placed alphabetically between `Mocktail` and `KubeStellar Console`.
- ✅ Quality: actively maintained (frequent releases), CI green, cosign-signed images, SBOMs attached.
- ✅ Disclosure: I'm a contributor to AgentTier.
